### PR TITLE
fix(app): chips binding example

### DIFF
--- a/packages/app/src/views/chips/binding.html
+++ b/packages/app/src/views/chips/binding.html
@@ -1,8 +1,0 @@
-<template>
-  <mdc-chip-set filter mdcchip:removal.trigger="removed($event.detail.data)">
-    <mdc-chip role="checkbox" checkmark repeat.for="c of chips" checked.bind="c.selected" trailing-icon="cancel"
-      data.bind="c">
-      ${c.label}
-    </mdc-chip>
-  </mdc-chip-set>
-</template>

--- a/packages/app/src/views/chips/examples.html
+++ b/packages/app/src/views/chips/examples.html
@@ -35,13 +35,8 @@
     <example-viewer html.bind="inputTrailingActionHtml"></example-viewer>
   </div>
   <div class="demo-content">
-    <h3 class="demo-content__headline">Binding</h3>
-    <div class="demo-layout__row">
-      <compose view="./binding.html"></compose>
-    </div>
-    <mdc-text-field value.bind="newChip"></mdc-text-field>
-    <mdc-button raised click.delegate="add()">Add</mdc-button>
-  </div>
-  <example-viewer html.bind="bindingHtml"></example-viewer>
+    <h3 class="demo-content__headline">Filter Chips with Binding</h3>
+    <compose view-model="./filter-binding"></compose>
+    <example-viewer html.bind="filterBindingHtml" code.bind="filterBindingCode"></example-viewer>
   </div>
 </template>

--- a/packages/app/src/views/chips/examples.ts
+++ b/packages/app/src/views/chips/examples.ts
@@ -5,6 +5,8 @@ import filterHtml from '!!raw-loader!./filter.html';
 import filterLeadingHtml from '!!raw-loader!./filter-leading.html';
 import inputHtml from '!!raw-loader!./input.html';
 import inputTrailingActionHtml from '!!raw-loader!./input-trailing-action.html';
+import filterBindingHtml from '!!raw-loader!./filter-binding.html';
+import filterBindingCode from '!!raw-loader!./filter-binding-code';
 
 export class Examples {
   defaultHtml = defaultHtml;
@@ -14,17 +16,6 @@ export class Examples {
   filterLeadingHtml = filterLeadingHtml;
   inputHtml = inputHtml;
   inputTrailingActionHtml = inputTrailingActionHtml;
-
-  chips = [{ label: 'One', selected: true }, { label: 'Two' }, { label: 'Three' }];
-  newChip: string;
-
-  add() {
-    this.chips.push({ label: this.newChip });
-    this.newChip = '';
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  removed(data: any) {
-    this.chips.splice(this.chips.indexOf(data), 1);
-  }
+  filterBindingHtml = filterBindingHtml;
+  filterBindingCode = filterBindingCode;
 }

--- a/packages/app/src/views/chips/filter-binding-code.ts
+++ b/packages/app/src/views/chips/filter-binding-code.ts
@@ -1,0 +1,14 @@
+
+export class FilterBinding {
+  chips = [{ label: 'One', selected: true }, { label: 'Two' }, { label: 'Three' }];
+  newChip: string;
+
+  add() {
+    this.chips.push({ label: this.newChip });
+    this.newChip = '';
+  }
+
+  removed(data: any) {
+    this.chips.splice(this.chips.indexOf(data), 1);
+  }
+}

--- a/packages/app/src/views/chips/filter-binding.html
+++ b/packages/app/src/views/chips/filter-binding.html
@@ -1,0 +1,15 @@
+<template>
+  <!-- <div style="display: block;"> -->
+  <div class="demo-layout__row">
+      <mdc-chip-set filter mdcchip:removal.trigger="removed($event.detail.data)">
+      <mdc-chip role="checkbox" checkmark repeat.for="c of chips"
+        checked.bind="c.selected" trailing-icon="cancel" data.bind="c">
+        ${c.label}
+      </mdc-chip>
+    </mdc-chip-set>
+  </div>
+  <div class="demo-layout__row">
+    <mdc-text-field value.bind="newChip"></mdc-text-field>
+    <mdc-button raised click.delegate="add()">Add</mdc-button>
+  </div>
+</template>

--- a/packages/app/src/views/chips/filter-binding.ts
+++ b/packages/app/src/views/chips/filter-binding.ts
@@ -1,0 +1,15 @@
+
+export class FilterBinding {
+  chips = [{ label: 'One', selected: true }, { label: 'Two' }, { label: 'Three' }];
+  newChip: string;
+
+  add() {
+    this.chips.push({ label: this.newChip });
+    this.newChip = '';
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  removed(data: any) {
+    this.chips.splice(this.chips.indexOf(data), 1);
+  }
+}


### PR DESCRIPTION
The binding example for chips did not show the code in the example viewer.
Also the example viewer button was outside of the section.