### PR TITLE
Range slider bugs

### DIFF
--- a/packages/slider/src/mdc-slider.ts
+++ b/packages/slider/src/mdc-slider.ts
@@ -53,6 +53,7 @@ export class MdcSlider extends MdcComponent<MdcSliderFoundationAurelia> {
       this.endInput.setAttribute(attributes.INPUT_MIN, this.min);
     }
     this.foundation?.init();
+    this.foundation?.layout();
   }
 
   @bindable
@@ -61,6 +62,7 @@ export class MdcSlider extends MdcComponent<MdcSliderFoundationAurelia> {
     await this.initialised;
     this.endInput.setAttribute(attributes.INPUT_MAX, this.max);
     this.foundation?.init();
+    this.foundation?.layout();
   }
 
   @bindable

--- a/packages/slider/src/mdc-slider.ts
+++ b/packages/slider/src/mdc-slider.ts
@@ -47,11 +47,7 @@ export class MdcSlider extends MdcComponent<MdcSliderFoundationAurelia> {
   min: string = '0';
   async minChanged() {
     await this.initialised;
-    if (this.startInput) {
-      this.startInput?.setAttribute(attributes.INPUT_MIN, this.min);
-    } else {
-      this.endInput.setAttribute(attributes.INPUT_MIN, this.min);
-    }
+    (this.startInput ?? this.endInput).setAttribute(attributes.INPUT_MIN, this.min);
     this.foundation?.init();
     this.foundation?.layout();
   }

--- a/packages/slider/src/mdc-slider.ts
+++ b/packages/slider/src/mdc-slider.ts
@@ -47,7 +47,11 @@ export class MdcSlider extends MdcComponent<MdcSliderFoundationAurelia> {
   min: string = '0';
   async minChanged() {
     await this.initialised;
-    this.endInput.setAttribute(attributes.INPUT_MIN, this.min);
+    if (this.startInput) {
+      this.startInput?.setAttribute(attributes.INPUT_MIN, this.min);
+    } else {
+      this.endInput.setAttribute(attributes.INPUT_MIN, this.min);
+    }
     this.foundation?.init();
   }
 


### PR DESCRIPTION
Fixes #37 

Not sure if there's a better way to fix view than calling `foundation.layout`

Using this also immediately updates other sliders when min/max is updated rather than waiting for some user input, this has the added benefit of not keeping the thumb at a position on the screen whilst the value for that position has changed.