### PR TITLE
Fixed init guide & layout-grid

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -6,7 +6,8 @@
 2. Fork the `aurelia-mdc-web` repo on GitHub.
 3. Clone your fork to your machine with `git clone`.
 4. From the root of the project, run `npm i` to install the dependencies.
-5. From the root of the project, run `npm run refresh` to bootstrap lerna.
+5. From the root of the project, run `npx lage init` to bootstrap `lage`.
+6. From the root of the project, run `npm run doc` to generate doc file for each package.
 
 ## <a name="demo-server"></a> Run demo application
 From the root of the project,

--- a/lage.config.js
+++ b/lage.config.js
@@ -3,6 +3,7 @@ module.exports = {
     build: ["^build"],
     test: ["build"],
     "update-versions": [],
-    "publish:au2": []
+    "publish:au2": [],
+    doc: [],
   },
 };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "build": "lage build --no-cache --verbose --no-deps",
     "publish:au2": "lage publish:au2",
     "start": "cd packages/app && npm start",
-    "doc": "lage doc --no-cache --verbose --no-deps",
+    "doc": "lage doc --no-cache",
     "changelog": "cross-env conventional-changelog -p angular -i docs/CHANGELOG.md -s",
     "deploy": "cross-env GIT_DEPLOY_REPO=\"https://github.com/aurelia-ui-toolkits/aurelia-mdc-web-au2-demo.git\" && cd packages/app && npm run build:app && cd ../.. && deploy.sh",
     "update-versions:root": "ts-node -P tsconfig.scripts.json scripts/update-versions.ts",

--- a/packages/layout-grid/src/mdc-layout-grid.html
+++ b/packages/layout-grid/src/mdc-layout-grid.html
@@ -4,4 +4,5 @@
   ${fixedColumnWidth ? 'mdc-layout-grid--fixed-column-width' : ''}
   ${noPadding ? 'mdc-layout-grid--no-padding' : ''}
   ">
+  <au-slot></au-slot>
 </template>


### PR DESCRIPTION
Developer's setup guide was not up to date - resolved it.
Added a new "docs" pipeline in lage config which was needed to generate `api.json` for each package automatically.
Fixed `mdc-layout-grid` because au-slot was missing so cells wasn't rendered.